### PR TITLE
Add completeness-indicator

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "ES2020",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
 


### PR DESCRIPTION
- Shows a checkmark on teams that are done with a round.
- Shows an asterisk on teams that have 11 players, but where the points
  can still change because they have starters that will still play

Incomplete (faked the data a bit to get a screenshot):
<img width="620" alt="image" src="https://github.com/stianjensen/sheplays-browser/assets/5347151/bf8652e8-fc28-41de-b585-3561893bf0cf">

Complete despite not 11:
<img width="583" alt="image" src="https://github.com/stianjensen/sheplays-browser/assets/5347151/914a2828-2002-4244-8fe9-5a660067fb75">
<img width="590" alt="image" src="https://github.com/stianjensen/sheplays-browser/assets/5347151/f94b1905-a4a0-4a08-a4ee-a955e36e8a2e">

