### PR TITLE
Introduce formation order

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -269,9 +269,10 @@ const FutureLineup = ({
     playerIds?.map((player, index) => {
       const playerInfo = players.find(it => it.playerId === player);
       if (playerInfo) {
-        const out = !countries[playerInfo.club][slug]?.remaining || playerInfo.injured;
+        const out = !countries[playerInfo.club][slug]?.remaining || (playerInfo.injured ?? undefined);
         return {
-          ...(playerInfo as PlayerInfo),
+          ...playerInfo,
+          position: playerInfo.position as Position,
           out,
           isDesignatedCaptain: index === 0,
           isDesignatedViceCaptain: index === 1,
@@ -328,8 +329,9 @@ const TeamRound = ({
       const countryPlayed = countries[playerInfo.club][slug]?.players > 0;
       const out = !countries[playerInfo.club][slug]?.remaining || (countryPlayed && !player.played);
       return {
-        ...(playerInfo as PlayerInfo),
+        ...playerInfo,
         ...player,
+        position: playerInfo.position as Position,
         out,
         isDesignatedCaptain: index === 0,
         isDesignatedViceCaptain: index === 1,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -157,6 +157,12 @@ const Player = ({playerInfo}: {playerInfo: FullPlayerRoundInfo}) => {
             minimumFractionDigits: 0,
           }).format(playerInfo.fantasyPrice)}
         </UncontrolledTooltip>
+        {playerInfo.isDesignatedCaptain && (
+          <div className="ms-2 badge rounded-pill bg-success-subtle text-success-emphasis">C</div>
+        )}
+        {playerInfo.isDesignatedViceCaptain && (
+          <div className="ms-2 badge rounded-pill bg-success-subtle text-success-emphasis">V</div>
+        )}
         {!playerInfo.played && !playerInfo.out && !playerInfo.injured && (
           <small>
             <span
@@ -261,7 +267,7 @@ const TeamRound = ({
 }) => {
   const [isOpen, setIsOpen] = useState(initialIsOpen ?? false);
 
-  const roundPlayers: (FullPlayerRoundInfo | undefined)[] = round.players.map(player => {
+  const roundPlayers: (FullPlayerRoundInfo | undefined)[] = round.players.map((player, index) => {
     const playerInfo = players.find(it => it.playerId === player.playerId);
     if (playerInfo) {
       const countryPlayed = countries[playerInfo.club][slug]?.players > 0;
@@ -270,6 +276,8 @@ const TeamRound = ({
         ...playerInfo,
         ...player,
         out,
+        isDesignatedCaptain: index === 0,
+        isDesignatedViceCaptain: index === 1,
       };
     } else {
       return undefined;

--- a/src/Stats.tsx
+++ b/src/Stats.tsx
@@ -3,6 +3,7 @@ import players from './data/players.json';
 import {Link} from 'react-router-dom';
 import {countryRemaining, countryToFlagMapping} from './data/countries';
 import {Country, PlayerPosition} from './App';
+import {Position} from './types';
 
 function calculatePlayerTotalScore(scores: (typeof players)[0]['score']): number {
   return scores ? Object.values(scores).reduce((a, b) => a + b, 0) : 0;
@@ -211,7 +212,7 @@ export const Stats = () => {
                     <Country country={player.country} />
                   </td>
                   <td className="text-center">
-                    <PlayerPosition position={player.position} />
+                    <PlayerPosition position={player.position as Position} />
                   </td>
                   <td>
                     <div className="d-flex align-items-baseline gap-2">

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+export type Position = 'GK' | 'DF' | 'MF' | 'FW';
+
 export type PlayerInfo =
   | {
       score: {
@@ -13,7 +15,7 @@ export type PlayerInfo =
       clubD?: string | null;
       playerId: string;
       fantasyPrice: number;
-      position: string;
+      position: Position;
     }
   | undefined;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -18,11 +18,13 @@ export type PlayerInfo =
   | undefined;
 
 export type PlayerRoundInfo = {
-  isCaptain?: boolean;
+  isCaptain?: boolean; // Is the player actually acting captain per now? (Highest ranking playing player)
   played?: boolean;
   benched?: boolean;
   points?: number;
   out?: boolean;
+  isDesignatedCaptain?: boolean; // Is the player selected as captain? (Tops the list, will be captain if she plays)
+  isDesignatedViceCaptain?: boolean; // Selected in position 2, right behind the captain
 };
 
 export type FullPlayerRoundInfo = PlayerInfo & PlayerRoundInfo;


### PR DESCRIPTION
Depends on #15 
- Add badges for captain and vice-captain
- Show players in formation instead of prio order
Will probably make this toggleable before its ready

<img width="556" alt="image" src="https://github.com/stianjensen/sheplays-browser/assets/5347151/cedae4a2-69fb-4a9a-89f6-0dbc92e6c5ca">

<img width="568" alt="image" src="https://github.com/stianjensen/sheplays-browser/assets/5347151/392c77cf-ade5-4738-a6b5-efe5293e475d">

<img width="563" alt="image" src="https://github.com/stianjensen/sheplays-browser/assets/5347151/daa4af83-cdf4-4788-af0a-8028aa1ccab5">
