### PR TITLE
Remove player number from expected interface

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -8,7 +8,6 @@ export type PlayerInfo =
       country: string;
       name: string;
       injured?: boolean | null;
-      number?: number | null;
       points: number;
       DOB: string;
       clubD?: string | null;


### PR DESCRIPTION
For some reason ShePlays suddenly switched Lauren James' number from a number to the boolean value True. We're not currently displaying numbers anyway, so we'll just remove that for now to avoid type checking errors.